### PR TITLE
improved send selection command, code cleaning

### DIFF
--- a/Rtools.py
+++ b/Rtools.py
@@ -37,12 +37,13 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
             selection += self.view.substr(region) + "\n"
         selection = (selection[::-1].replace('\n'[::-1], '', 1))[::-1]
 
-      # only proceed if selection is not empty
+        # only proceed if selection is not empty
         if(selection != ""):
-            extension = os.path.splitext(self.view.file_name())[1]
+            # get name of syntax file
+            lang = self.view.settings().get('syntax')
 
         # R file
-        if(extension.lower() == ".r"):
+        if "R.tmLanguage" in lang:
             # define list of arguments
             args = ['osascript', '-e', 'tell app "R64" to activate']
             # split selection into lines

--- a/Rtools.py
+++ b/Rtools.py
@@ -1,51 +1,55 @@
-import sublime, sublime_plugin
-import os, subprocess, string
+import sublime
+import sublime_plugin
+import os
+import subprocess
+import string
+
 
 class RDocsCommand(sublime_plugin.TextCommand):
-   def run(self, edit):
-      sel = self.view.sel()[0]
+    def run(self, edit):
+        sel = self.view.sel()[0]
 
-      params_reg = self.view.find('(?<=\().*(?=\))', sel.begin())
-      params_txt = self.view.substr(params_reg)
-      params = params_txt.split(',')
+        params_reg = self.view.find('(?<=\().*(?=\))', sel.begin())
+        params_txt = self.view.substr(params_reg)
+        params = params_txt.split(',')
 
-      snippet = "#'<brief desc>\n#'\n#'<full description>\n"
+        snippet = "#'<brief desc>\n#'\n#'<full description>\n"
 
-      for p in params:
-         snippet += "#' @param %s <what param does>\n" % p
+        for p in params:
+            snippet += "#' @param %s <what param does>\n" % p
 
-      snippet+= "#' @export\n #' @keywords\n#' @seealso\n#' @return\n#' @alias\n#' @examples \dontrun{\n#'\n#'}\n"
+        snippet += "#' @export\n #' @keywords\n#' @seealso\n#' @return\n#' @alias\n#' @examples \dontrun{\n#'\n#'}\n"
 
-      self.view.insert(edit, sel.begin(), snippet)
+        self.view.insert(edit, sel.begin(), snippet)
 
 
 class SendSelectionCommand(sublime_plugin.TextCommand):
-   @staticmethod
-   def cleanString(str):
-      str=string.replace(str,'\\','\\\\')
-      str=string.replace(str,'"','\\"')
-      return str
+    @staticmethod
+    def cleanString(str):
+        str = string.replace(str, '\\', '\\\\')
+        str = string.replace(str, '"', '\\"')
+        return str
 
-   def run(self, edit):
-      # get selection
-      selection = ""
-      for region in self.view.sel():
-         selection+=self.view.substr(region) + "\n"
-      selection = (selection[::-1].replace('\n'[::-1], '', 1))[::-1]
+    def run(self, edit):
+        # get selection
+        selection = ""
+        for region in self.view.sel():
+            selection += self.view.substr(region) + "\n"
+        selection = (selection[::-1].replace('\n'[::-1], '', 1))[::-1]
 
       # only proceed if selection is not empty
-      if(selection!=""):
-         extension = os.path.splitext(self.view.file_name())[1]
+        if(selection != ""):
+            extension = os.path.splitext(self.view.file_name())[1]
 
-         # R file
-         if(extension.lower()==".r"):
+        # R file
+        if(extension.lower() == ".r"):
             # define list of arguments
-            args=['osascript','-e','tell app "R64" to activate']
+            args = ['osascript', '-e', 'tell app "R64" to activate']
             # split selection into lines
-            selection=self.cleanString(selection).split("\n")
+            selection = self.cleanString(selection).split("\n")
             # add code lines to list of arguments
             for part in selection:
-               args.extend(['-e', 'tell app "R64" to cmd "' + part + '"\n'])
+                args.extend(['-e', 'tell app "R64" to cmd "' + part + '"\n'])
             # execute code and activate ST2
             p = subprocess.Popen(args)
             subprocess.Popen("""osascript -e 'tell app "Sublime Text 2" to activate' """, shell=True)

--- a/Rtools.py
+++ b/Rtools.py
@@ -44,13 +44,14 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
 
         # R file
         if "R.tmLanguage" in lang:
-            # define list of arguments
-            args = ['osascript', '-e', 'tell app "R64" to activate']
             # split selection into lines
             selection = self.cleanString(selection).split("\n")
+            # define osascript arguments
+            args = ['osascript', '-e', 'tell app "R64" to activate']
             # add code lines to list of arguments
             for part in selection:
                 args.extend(['-e', 'tell app "R64" to cmd "' + part + '"\n'])
-            # execute code and activate ST2
-            p = subprocess.Popen(args)
-            subprocess.Popen("""osascript -e 'tell app "Sublime Text 2" to activate' """, shell=True)
+            # activate ST2
+            args.extend(['-e', 'tell app "Sublime Text 2" to activate'])
+            # execute code
+            subprocess.Popen(args)


### PR DESCRIPTION
Hi, 

it's great to see someone pick this up (I made the original post in the ST2 forum). Thanks! 

Here are a couple of improvements:

1) different way to determine whether the code is r. The previous version relied on the file ending, which required the user to save the file first. This version uses the ST2 language definition (what you see in the bottom right corner) so that you can already send selection before the file is saved. 

2) slightly improved code for calling osascript. E.g. the reactivation of ST2 is now integrated in the main subprocess call and works much more reliable. 

3) Code cleaning based on a python linter. That's why the whole file is different. Let me if that bothers you and I will send a separate pull request without the linting. I am using the package SublimeLinter, which works pretty well for Python. 

I have some suggestions for additional features and might make some more contribution (but I am pretty busy right now). Should I open tickets on github or do you prefer a different channel...
