### PR TITLE
Fix unbound 'lang' error

### DIFF
--- a/Rtools.py
+++ b/Rtools.py
@@ -38,9 +38,11 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
         selection = (selection[::-1].replace('\n'[::-1], '', 1))[::-1]
 
         # only proceed if selection is not empty
-        if(selection != ""):
-            # get name of syntax file
-            lang = self.view.settings().get('syntax')
+        if(selection == ""):
+            return
+
+        # get name of syntax file
+        lang = self.view.settings().get('syntax')
 
         # R file
         if "R.tmLanguage" in lang:


### PR DESCRIPTION
When no text is selected and you press cmd-Enter, it gives this error in the ST console:

```
Traceback (most recent call last):
  File "./sublime_plugin.py", line 350, in run_
  File "./Rtools.py", line 46, in run
UnboundLocalError: local variable 'lang' referenced before assignment
```

This pull request changes the logic so that it doesn't give that error anymore; it quits if there's no text.
