### PR TITLE
Run line when nothing is selected

### DIFF
--- a/Rtools.py
+++ b/Rtools.py
@@ -34,7 +34,12 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
         # get selection
         selection = ""
         for region in self.view.sel():
-            selection += self.view.substr(region) + "\n"
+            if region.empty():
+                selection += self.view.substr(self.view.line(region)) + "\n"
+                self.advanceCursor(region)
+            else:
+                selection += self.view.substr(region) + "\n"
+
         selection = (selection[::-1].replace('\n'[::-1], '', 1))[::-1]
 
         # only proceed if selection is not empty
@@ -57,3 +62,18 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
             args.extend(['-e', 'tell app "Sublime Text 2" to activate'])
             # execute code
             subprocess.Popen(args)
+
+
+    def advanceCursor(self, region):
+        (row, col) = self.view.rowcol(region.begin())
+
+        # Make sure not to go past end of next line
+        nextline = self.view.line(self.view.text_point(row + 1, 0))
+        if nextline.size() < col:
+            loc = self.view.text_point(row + 1, nextline.size())
+        else:
+            loc = self.view.text_point(row + 1, col)
+
+        # Remove the old region and add the new one
+        self.view.sel().subtract(region)
+        self.view.sel().add(sublime.Region(loc, loc))


### PR DESCRIPTION
When no text is selected, pressing cmd-Enter runs the entire line, and advances the cursor to the next line. (This is similar to how rstudio works.)

If there are multiple regions, it only does this for those regions that have no selection (i.e., cursors with no selection).

The code for moving the cursor comes is borrowed from:
http://www.sublimetext.com/forum/viewtopic.php?f=6&t=2819

It basically removes the old regions and adds new ones.
