### PR TITLE
Don't bring R window to front to run code

### DIFF
--- a/Rtools.py
+++ b/Rtools.py
@@ -47,11 +47,9 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
             # split selection into lines
             selection = self.cleanString(selection).split("\n")
             # define osascript arguments
-            args = ['osascript', '-e', 'tell app "R64" to activate']
+            args = ['osascript']
             # add code lines to list of arguments
             for part in selection:
                 args.extend(['-e', 'tell app "R64" to cmd "' + part + '"\n'])
-            # activate ST2
-            args.extend(['-e', 'tell app "Sublime Text 2" to activate'])
             # execute code
             subprocess.Popen(args)


### PR DESCRIPTION
This makes it NOT bring the R program to the front to activate the code. I found the "blink" kind of distracting, and when it brought ST2 back to the front, sometimes other ST2 windows which were previously behind the R window got moved in front of the R window.

This change address both issues.
