### PR TITLE
Allow Embedded R to access R Tools Commands

### DIFF
--- a/Rtools.py
+++ b/Rtools.py
@@ -32,7 +32,8 @@ class SendSelectionCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         # Check if it's an R file
-        if "R.tmLanguage" not in self.view.settings().get('syntax'):
+        filescope = self.view.syntax_name(self.view.sel()[0].b)
+        if ("source.r " not in filescope) and ("source.r." not in filescope):
             return
 
         # get selection


### PR DESCRIPTION
Changed checking for R file `.tmlanguage` file to checking for a `source.r` in the current scope, which allows other documents using embedded R (SWeave, Knitr) to use R Tools commands.
